### PR TITLE
Fix links for yaml

### DIFF
--- a/src/ApiCodeGenerator.MSBuild/build/ApiCodeGenerator.MSBuild.props
+++ b/src/ApiCodeGenerator.MSBuild/build/ApiCodeGenerator.MSBuild.props
@@ -39,11 +39,11 @@
     </_Temporary1>
     <_Temporary1 Include="@(_Temporary)">
       <OpenApiPath>%(DocumentDir)%(FileName).yml</OpenApiPath>
-      <Options>%(FullPath)</Options>
+      <Options>%(Identity)</Options>
     </_Temporary1>
     <_Temporary1 Include="@(_Temporary)">
       <OpenApiPath>%(DocumentDir)%(FileName).yaml</OpenApiPath>
-      <Options>%(FullPath)</Options>
+      <Options>%(Identity)</Options>
     </_Temporary1>
 
     <_OpenApiReference Include="@(_Temporary1 -&gt; '%(OpenApiPath)')"


### PR DESCRIPTION
When using the AcgApiDocumentLinkNearNswag property, yaml files did not appear in Solution Explorer.